### PR TITLE
Fix YAML Change in Symfony 2.8/3.0

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,6 +8,7 @@ services:
     tebru_retrofit.services_warmer:
         class: Tebru\RetrofitBundle\Cache\ServicesWarmer
         public: false
-        arguments: [@service_container]
+        arguments:
+            - "@service_container"
         tags:
             - { name: kernel.cache_warmer }


### PR DESCRIPTION
Quote service reference in services.yml

Starting a string with @ without quoting it has been deprecated in
Symfony 2.8 and removed in Symfony 3.0.
